### PR TITLE
Fix use of fixed seed 123 for HFO

### DIFF
--- a/src/referee.cpp
+++ b/src/referee.cpp
@@ -3155,7 +3155,7 @@ HFORef::playModeChange( PlayMode pm )
           {
             int seed = irand(RAND_MAX);
             std::cout << "HFORef using Random Seed: " << seed << std::endl;
-            M_rng.seed(123);
+            M_rng.seed(seed);
           }
           const Stadium::PlayerCont::const_iterator end = M_stadium.players().end();
           for ( Stadium::PlayerCont::const_iterator p = M_stadium.players().begin();


### PR DESCRIPTION
Now, if M_random_seed (via ServerParam::instance().randomSeed()) is the default -1 (or below), "irand" will use the "rcss::random::DefaultRNG" to generate the seed.