### PR TITLE
Add ball y parameters for HFORef::resetField()

### DIFF
--- a/src/referee.cpp
+++ b/src/referee.cpp
@@ -3243,6 +3243,9 @@ HFORef::resetField()
     double ball_y = drand(min_ball_y / 2.0 * pitch_width,
                           max_ball_y / 2.0 * pitch_width, M_rng);
     std::cout << min_ball_y << ", " << max_ball_y << ": " << ball_y << std::endl;
+    std::cerr << min_ball_y << ", " << max_ball_y << ": " << ball_y << std::endl;
+    std::clog << min_ball_y << ", " << max_ball_y << ": " << ball_y << std::endl;
+
     // double ball_y = drand(-.4 * pitch_width, .4 * pitch_width, M_rng);
     M_stadium.placeBall( NEUTRAL, PVector(ball_x, ball_y) );
     M_prev_ball_pos = M_stadium.ball().pos();

--- a/src/referee.cpp
+++ b/src/referee.cpp
@@ -3242,7 +3242,11 @@ HFORef::resetField()
     max_ball_y = std::max(max_ball_y, min_ball_y);
     double ball_y = drand(min_ball_y / 2.0 * pitch_width,
                           max_ball_y / 2.0 * pitch_width, M_rng);
-    M_stadium.logger().hfoLog() << min_ball_y << "\t" << max_ball_y << "\t" << ball_y << std::endl;
+    M_stadium.logger().hfoLog() << ServerParam::instance().hfoMinBallY() << "\t"
+                                << min_ball_y << "\t"
+                                << ServerParam::instance().hfoMaxBallY() << "\t"
+                                << max_ball_y << "\t"
+                                << ball_y << std::endl;
     // std::cout << min_ball_y << ", " << max_ball_y << ": " << ball_y << std::endl;
     // std::cerr << min_ball_y << ", " << max_ball_y << ": " << ball_y << std::endl;
     // std::clog << min_ball_y << ", " << max_ball_y << ": " << ball_y << std::endl;

--- a/src/referee.cpp
+++ b/src/referee.cpp
@@ -3240,9 +3240,9 @@ HFORef::resetField()
     double max_ball_y =
         std::max(std::min(ServerParam::instance().hfoMaxBallY(), 1.), -1.);
     max_ball_y = std::max(max_ball_y, min_ball_y);
-    double ball_y = drand(min_ball_y / 2.0 * pitch_width,
-                          max_ball_y / 2.0 * pitch_width, M_rng);
-    // double ball_y = drand(-.4 * pitch_width, .4 * pitch_width, M_rng);
+    // double ball_y = drand(min_ball_y / 2.0 * pitch_width,
+    //                       max_ball_y / 2.0 * pitch_width, M_rng);
+    double ball_y = drand(-.4 * pitch_width, .4 * pitch_width, M_rng);
     M_stadium.placeBall( NEUTRAL, PVector(ball_x, ball_y) );
     M_prev_ball_pos = M_stadium.ball().pos();
     boost::variate_generator<boost::mt19937&, boost::uniform_int<> >

--- a/src/referee.cpp
+++ b/src/referee.cpp
@@ -3242,9 +3242,10 @@ HFORef::resetField()
     max_ball_y = std::max(max_ball_y, min_ball_y);
     double ball_y = drand(min_ball_y / 2.0 * pitch_width,
                           max_ball_y / 2.0 * pitch_width, M_rng);
-    std::cout << min_ball_y << ", " << max_ball_y << ": " << ball_y << std::endl;
-    std::cerr << min_ball_y << ", " << max_ball_y << ": " << ball_y << std::endl;
-    std::clog << min_ball_y << ", " << max_ball_y << ": " << ball_y << std::endl;
+    M_stadium.logger().hfoLog() << min_ball_y << "\t" << max_ball_y << "\t" << ball_y << std::endl;
+    // std::cout << min_ball_y << ", " << max_ball_y << ": " << ball_y << std::endl;
+    // std::cerr << min_ball_y << ", " << max_ball_y << ": " << ball_y << std::endl;
+    // std::clog << min_ball_y << ", " << max_ball_y << ": " << ball_y << std::endl;
 
     // double ball_y = drand(-.4 * pitch_width, .4 * pitch_width, M_rng);
     M_stadium.placeBall( NEUTRAL, PVector(ball_x, ball_y) );

--- a/src/referee.cpp
+++ b/src/referee.cpp
@@ -3240,9 +3240,10 @@ HFORef::resetField()
     double max_ball_y =
         std::max(std::min(ServerParam::instance().hfoMaxBallY(), 1.), -1.);
     max_ball_y = std::max(max_ball_y, min_ball_y);
-    // double ball_y = drand(min_ball_y / 2.0 * pitch_width,
-    //                       max_ball_y / 2.0 * pitch_width, M_rng);
-    double ball_y = drand(-.4 * pitch_width, .4 * pitch_width, M_rng);
+    double ball_y = drand(min_ball_y / 2.0 * pitch_width,
+                          max_ball_y / 2.0 * pitch_width, M_rng);
+    std::cout << min_ball_y << ", " << max_ball_y << ": " << ball_y << std::endl;
+    // double ball_y = drand(-.4 * pitch_width, .4 * pitch_width, M_rng);
     M_stadium.placeBall( NEUTRAL, PVector(ball_x, ball_y) );
     M_prev_ball_pos = M_stadium.ball().pos();
     boost::variate_generator<boost::mt19937&, boost::uniform_int<> >

--- a/src/referee.cpp
+++ b/src/referee.cpp
@@ -3242,16 +3242,6 @@ HFORef::resetField()
     max_ball_y = std::max(max_ball_y, min_ball_y);
     double ball_y = drand(min_ball_y / 2.0 * pitch_width,
                           max_ball_y / 2.0 * pitch_width, M_rng);
-    M_stadium.logger().hfoLog() << ServerParam::instance().hfoMinBallY() << "\t"
-                                << min_ball_y << "\t"
-                                << ServerParam::instance().hfoMaxBallY() << "\t"
-                                << max_ball_y << "\t"
-                                << ball_y << std::endl;
-    // std::cout << min_ball_y << ", " << max_ball_y << ": " << ball_y << std::endl;
-    // std::cerr << min_ball_y << ", " << max_ball_y << ": " << ball_y << std::endl;
-    // std::clog << min_ball_y << ", " << max_ball_y << ": " << ball_y << std::endl;
-
-    // double ball_y = drand(-.4 * pitch_width, .4 * pitch_width, M_rng);
     M_stadium.placeBall( NEUTRAL, PVector(ball_x, ball_y) );
     M_prev_ball_pos = M_stadium.ball().pos();
     boost::variate_generator<boost::mt19937&, boost::uniform_int<> >

--- a/src/referee.cpp
+++ b/src/referee.cpp
@@ -3235,7 +3235,14 @@ HFORef::resetField()
     max_ball_x = std::max(max_ball_x, min_ball_x);
     double ball_x = drand(min_ball_x * half_pitch_length,
                           max_ball_x * half_pitch_length, M_rng);
-    double ball_y = drand(-.4 * pitch_width, .4 * pitch_width, M_rng);
+    double min_ball_y =
+        std::max(std::min(ServerParam::instance().hfoMinBallY(), 1.), -1.);
+    double max_ball_y =
+        std::max(std::min(ServerParam::instance().hfoMaxBallY(), 1.), -1.);
+    max_ball_y = std::max(max_ball_y, min_ball_y);
+    double ball_y = drand(min_ball_y / 2.0 * pitch_width,
+                          max_ball_y / 2.0 * pitch_width, M_rng);
+    // double ball_y = drand(-.4 * pitch_width, .4 * pitch_width, M_rng);
     M_stadium.placeBall( NEUTRAL, PVector(ball_x, ball_y) );
     M_prev_ball_pos = M_stadium.ball().pos();
     boost::variate_generator<boost::mt19937&, boost::uniform_int<> >

--- a/src/serverparam.cpp
+++ b/src/serverparam.cpp
@@ -858,6 +858,8 @@ ServerParam::addParams()
     addParam( "hfo_offense_on_ball", M_hfo_offense_on_ball, "", 9 );
     addParam( "hfo_min_ball_pos_x", M_hfo_min_ball_pos_x, "", 9 );
     addParam( "hfo_max_ball_pos_x", M_hfo_max_ball_pos_x, "", 9 );
+    addParam( "hfo_min_ball_pos_y", M_hfo_min_ball_pos_y, "", 9 );
+    addParam( "hfo_max_ball_pos_y", M_hfo_max_ball_pos_y, "", 9 );
 
     addParam( "nr_normal_halfs",
               rcss::conf::makeSetter( this, &ServerParam::setNrNormalHalfs ),

--- a/src/serverparam.h
+++ b/src/serverparam.h
@@ -427,6 +427,8 @@ private:
     int M_hfo_offense_on_ball; /* Give the ball to an offensive player */
     double M_hfo_min_ball_pos_x; /* Governs the initialization x-position of ball */
     double M_hfo_max_ball_pos_x; /* Governs the initialization x-position of ball */
+    double M_hfo_min_ball_pos_y; /* Governs the initialization y-position of ball */
+    double M_hfo_max_ball_pos_y; /* Governs the initialization y-position of ball */
     int M_port; /* port number */
     int M_coach_port; /* coach port number */
     int M_olcoach_port; /* online coach port number */
@@ -772,6 +774,8 @@ public:
     int hfoOffenseOnBall() const { return M_hfo_offense_on_ball; }
     double hfoMinBallX() const { return M_hfo_min_ball_pos_x; }
     double hfoMaxBallX() const { return M_hfo_max_ball_pos_x; }
+    double hfoMinBallY() const { return M_hfo_min_ball_pos_y; }
+    double hfoMaxBallY() const { return M_hfo_max_ball_pos_y; }
 
     double cornerKickMargin() const { return M_corner_kick_margin; }
     double offsideActiveArea() const { return M_offside_active_area_size; }


### PR DESCRIPTION
This PR adds ball y-min and y-max parameters that can be set with the command line. The range of values is -1.0 to 1.0 which corresponds with the top of the field to the bottom of the field, respectively. 

This PR should be followed by a corresponding PR for LARG/HFO which sets the default for these values to -0.8 and 0.8. Since the previous version of rcssserver set the y range to -0.4 to 0.4 of the `pitch_width`, the default functionality is unchanged.

If merged, consideration should be given to the corresponding PR in [LARG/HFO](https://github.com/LARG/HFO/pull/54).