### PR TITLE
Fix for building on Ubuntu >= 17.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 2.8.12)
+add_definitions(-std=c++03)
 project(rcssserver)
 
 find_package(Boost COMPONENTS system filesystem REQUIRED)


### PR DESCRIPTION
On Ubuntu >= 17.04 this is required to successfully build using make.
See: https://github.com/rcsoccersim/rcssserver/issues/1
